### PR TITLE
Add circle gesture detection system

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -423,6 +423,203 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+
+--- !u!1 &1000543211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1000543212}
+  m_Layer: 0
+  m_Name: Gesture Pivot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1000543212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1000543211}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1467000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1467000001}
+  - component: {fileID: 1467000002}
+  - component: {fileID: 1467000003}
+  - component: {fileID: 1467000004}
+  m_Layer: 0
+  m_Name: Tracked Orb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1467000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.5, y: 1, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1467000002
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467000000}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1467000003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467000000}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10302, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &1467000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1467000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 91ad80ddda6447ddb81ae680aceacb69, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  pivot: {fileID: 1000543212}
+  radius: 1.5
+  axis: {x: 0, y: 1, z: 0}
+  revolutionDuration: 4
+  alignOnStart: 1
+--- !u!1 &1890000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1890000001}
+  - component: {fileID: 1890000002}
+  m_Layer: 0
+  m_Name: Gesture System
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1890000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890000000}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1890000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1890000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 01302667ee034551badcdcaa86004891, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  trackedObjects:
+  - target: {fileID: 1467000001}
+  sampleInterval: 0.05
+  minPointDistance: 0.005
+  maxSampleAge: 3
+  minSampleCount: 25
+  minCircleRadius: 0.1
+  radiusVarianceTolerance: 0.2
+  minCoverageAngle: 300
+  minTravelledCircumferenceRatio: 0.75
+  detectionCooldown: 1
+  logDetections: 1
+  drawDebug: 1
+  trailColor: {r: 0, g: 1, b: 1, a: 1}
+  circleColor: {r: 0, g: 1, b: 0, a: 1}
+  onCircleDetected:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: GestureRecognition.GestureDetector+CircleGestureEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -430,3 +627,6 @@ SceneRoots:
   - {fileID: 330585546}
   - {fileID: 410087041}
   - {fileID: 832575519}
+  - {fileID: 1000543212}
+  - {fileID: 1467000001}
+  - {fileID: 1890000001}

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d546ed942d6047b58562092a1e018463
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Demo.meta
+++ b/Assets/Scripts/Demo.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16b8decf819e44baba99cea0eaccce30
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Demo/CircularMover.cs
+++ b/Assets/Scripts/Demo/CircularMover.cs
@@ -1,0 +1,117 @@
+using UnityEngine;
+
+namespace GestureRecognition.Demo
+{
+    /// <summary>
+    /// Simple helper that moves an object in a circular path around a pivot.
+    /// Useful for testing the <see cref="GestureDetector"/> without manual input.
+    /// </summary>
+    public class CircularMover : MonoBehaviour
+    {
+        [SerializeField]
+        private Transform pivot;
+
+        [SerializeField]
+        private float radius = 1.5f;
+
+        [SerializeField]
+        private Vector3 axis = Vector3.up;
+
+        [SerializeField]
+        [Tooltip("Time in seconds required to complete a full revolution.")]
+        private float revolutionDuration = 4f;
+
+        [SerializeField]
+        [Tooltip("If enabled, the object will be repositioned to match the desired radius when play mode starts.")]
+        private bool alignOnStart = true;
+
+        private float angularSpeed;
+
+        private void Awake()
+        {
+            axis = axis.sqrMagnitude > 0f ? axis.normalized : Vector3.up;
+        }
+
+        private void OnValidate()
+        {
+            radius = Mathf.Max(0.01f, radius);
+            revolutionDuration = Mathf.Max(0.01f, revolutionDuration);
+            axis = axis.sqrMagnitude > 0f ? axis.normalized : Vector3.up;
+            angularSpeed = 360f / revolutionDuration;
+        }
+
+        private void Start()
+        {
+            if (pivot == null)
+            {
+                Debug.LogWarning($"[{nameof(CircularMover)}] No pivot assigned on '{name}'.");
+                return;
+            }
+
+            angularSpeed = 360f / revolutionDuration;
+
+            if (alignOnStart)
+            {
+                Vector3 offset = transform.position - pivot.position;
+                offset = Vector3.ProjectOnPlane(offset, axis);
+                if (offset.sqrMagnitude < 1e-6f)
+                {
+                    offset = Vector3.Cross(axis, Vector3.forward);
+                    if (offset.sqrMagnitude < 1e-6f)
+                    {
+                        offset = Vector3.Cross(axis, Vector3.up);
+                    }
+                }
+
+                offset = offset.normalized * radius;
+                transform.position = pivot.position + offset;
+            }
+        }
+
+        private void Update()
+        {
+            if (pivot == null)
+            {
+                return;
+            }
+
+            transform.RotateAround(pivot.position, axis, angularSpeed * Time.deltaTime);
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmosSelected()
+        {
+            if (pivot == null)
+            {
+                return;
+            }
+
+            Vector3 normal = axis.sqrMagnitude > 0f ? axis.normalized : Vector3.up;
+            Vector3 axisX = Vector3.ProjectOnPlane(Vector3.right, normal);
+            if (axisX.sqrMagnitude < 1e-4f)
+            {
+                axisX = Vector3.ProjectOnPlane(Vector3.up, normal);
+            }
+
+            axisX.Normalize();
+            Vector3 axisY = Vector3.Cross(normal, axisX).normalized;
+
+            Vector3 center = pivot.position;
+            Vector3 previous = center + axisX * radius;
+
+            const int segments = 48;
+            Gizmos.color = Color.yellow;
+            for (int i = 1; i <= segments; i++)
+            {
+                float angle = (i / (float)segments) * Mathf.PI * 2f;
+                Vector3 next = center + (Mathf.Cos(angle) * axisX + Mathf.Sin(angle) * axisY) * radius;
+                Gizmos.DrawLine(previous, next);
+                previous = next;
+            }
+
+            Gizmos.color = Color.white;
+            Gizmos.DrawLine(center, transform.position);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Demo/CircularMover.cs.meta
+++ b/Assets/Scripts/Demo/CircularMover.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91ad80ddda6447ddb81ae680aceacb69
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Gestures.meta
+++ b/Assets/Scripts/Gestures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c000d49a38945589d24af27750c1268
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Gestures/GestureDetector.cs
+++ b/Assets/Scripts/Gestures/GestureDetector.cs
@@ -1,0 +1,419 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace GestureRecognition
+{
+    /// <summary>
+    /// Tracks the movement history of configured objects and raises events when a gesture is recognised.
+    /// Currently supports detecting circular motion.
+    /// </summary>
+    public class GestureDetector : MonoBehaviour
+    {
+        [Serializable]
+        public class TrackedObject
+        {
+            [Tooltip("Transform that will be analysed for gesture recognition.")]
+            public Transform target;
+
+            [NonSerialized]
+            internal readonly List<Sample> samples = new List<Sample>();
+
+            [NonSerialized]
+            internal float lastCircleTime = float.NegativeInfinity;
+
+            [NonSerialized]
+            internal bool hasLastCircle;
+
+            [NonSerialized]
+            internal Vector3 lastCircleCenter;
+
+            [NonSerialized]
+            internal float lastCircleRadius;
+        }
+
+        private struct Sample
+        {
+            public Vector3 position;
+            public float time;
+        }
+
+        [Serializable]
+        public class CircleGestureEvent : UnityEvent<Transform, Vector3, float>
+        {
+        }
+
+        [Header("Tracked Objects")]
+        [SerializeField]
+        private List<TrackedObject> trackedObjects = new List<TrackedObject>();
+
+        [SerializeField]
+        [Min(0.005f)]
+        [Tooltip("Interval in seconds between position samples for each tracked object.")]
+        private float sampleInterval = 0.05f;
+
+        [SerializeField]
+        [Tooltip("Minimum distance an object must move before a new sample is stored.")]
+        private float minPointDistance = 0.005f;
+
+        [SerializeField]
+        [Tooltip("Maximum lifetime of stored samples in seconds.")]
+        private float maxSampleAge = 3f;
+
+        [SerializeField]
+        [Tooltip("Minimum number of samples required before gesture analysis starts.")]
+        private int minSampleCount = 25;
+
+        [Header("Circle Detection")]
+        [SerializeField]
+        [Tooltip("Minimum acceptable radius for a detected circular gesture (world units).")]
+        private float minCircleRadius = 0.1f;
+
+        [SerializeField]
+        [Range(0.01f, 0.5f)]
+        [Tooltip("Maximum allowed relative standard deviation of the radius across sampled points.")]
+        private float radiusVarianceTolerance = 0.2f;
+
+        [SerializeField]
+        [Range(90f, 360f)]
+        [Tooltip("Minimum angular coverage in degrees before a circular gesture is considered complete.")]
+        private float minCoverageAngle = 300f;
+
+        [SerializeField]
+        [Range(0.2f, 1.5f)]
+        [Tooltip("Required ratio between the travelled distance and the circle circumference.")]
+        private float minTravelledCircumferenceRatio = 0.75f;
+
+        [SerializeField]
+        [Tooltip("Cooldown between detections for the same object to avoid repeated triggers (seconds).")]
+        private float detectionCooldown = 1f;
+
+        [Header("Debug")] 
+        [SerializeField]
+        [Tooltip("If enabled, successful detections are logged to the Unity console.")]
+        private bool logDetections = true;
+
+        [SerializeField]
+        [Tooltip("Draws the captured trail and last detected circle in the scene view during play mode.")]
+        private bool drawDebug = true;
+
+        [SerializeField]
+        private Color trailColor = Color.cyan;
+
+        [SerializeField]
+        private Color circleColor = Color.green;
+
+        [SerializeField]
+        private CircleGestureEvent onCircleDetected = new CircleGestureEvent();
+
+        private float sampleTimer;
+
+        /// <summary>
+        /// Event invoked whenever a tracked object performs a circular gesture.
+        /// Provides the transform, detected circle center and radius.
+        /// </summary>
+        public CircleGestureEvent OnCircleDetected => onCircleDetected;
+
+        private void Update()
+        {
+            sampleTimer += Time.deltaTime;
+            if (sampleTimer < sampleInterval)
+            {
+                return;
+            }
+
+            sampleTimer = 0f;
+            float currentTime = Time.time;
+
+            for (int i = trackedObjects.Count - 1; i >= 0; i--)
+            {
+                TrackedObject tracked = trackedObjects[i];
+                if (tracked?.target == null)
+                {
+                    continue;
+                }
+
+                SampleObject(tracked, currentTime);
+
+                if (tracked.samples.Count < minSampleCount)
+                {
+                    continue;
+                }
+
+                if (TryDetectCircle(tracked, currentTime, out Vector3 center, out float radius))
+                {
+                    tracked.lastCircleTime = currentTime;
+                    tracked.hasLastCircle = true;
+                    tracked.lastCircleCenter = center;
+                    tracked.lastCircleRadius = radius;
+
+                    onCircleDetected.Invoke(tracked.target, center, radius);
+
+                    if (logDetections)
+                    {
+                        Debug.Log($"[{nameof(GestureDetector)}] Circle detected for '{tracked.target.name}' at {center} with radius {radius:0.###}.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Registers a new transform for gesture detection at runtime.
+        /// </summary>
+        public void Register(Transform target)
+        {
+            if (target == null || trackedObjects.Exists(t => t.target == target))
+            {
+                return;
+            }
+
+            trackedObjects.Add(new TrackedObject { target = target });
+        }
+
+        /// <summary>
+        /// Removes a transform from gesture detection and clears its history.
+        /// </summary>
+        public void Unregister(Transform target)
+        {
+            trackedObjects.RemoveAll(t => t.target == target);
+        }
+
+        /// <summary>
+        /// Clears the stored trail for a specific transform, forcing gesture detection to restart.
+        /// </summary>
+        public void ClearHistory(Transform target)
+        {
+            TrackedObject tracked = trackedObjects.Find(t => t.target == target);
+            if (tracked != null)
+            {
+                tracked.samples.Clear();
+                tracked.hasLastCircle = false;
+            }
+        }
+
+#if UNITY_EDITOR
+        private void OnDrawGizmos()
+        {
+            if (!drawDebug || !Application.isPlaying)
+            {
+                return;
+            }
+
+            foreach (TrackedObject tracked in trackedObjects)
+            {
+                if (tracked == null || tracked.samples.Count < 2)
+                {
+                    continue;
+                }
+
+                Gizmos.color = trailColor;
+                for (int i = 1; i < tracked.samples.Count; i++)
+                {
+                    Gizmos.DrawLine(tracked.samples[i - 1].position, tracked.samples[i].position);
+                }
+
+                if (tracked.hasLastCircle)
+                {
+                    DrawCircleGizmo(tracked.lastCircleCenter, tracked.lastCircleRadius, tracked.samples);
+                }
+            }
+        }
+
+        private void DrawCircleGizmo(Vector3 center, float radius, List<Sample> samples)
+        {
+            Gizmos.color = circleColor;
+
+            const int segments = 64;
+            Vector3 normal = EstimateNormal(samples, center);
+            Vector3 axisX = Vector3.ProjectOnPlane(Vector3.right, normal);
+            if (axisX.sqrMagnitude < 1e-4f)
+            {
+                axisX = Vector3.ProjectOnPlane(Vector3.up, normal);
+            }
+
+            axisX.Normalize();
+            Vector3 axisY = Vector3.Cross(normal, axisX).normalized;
+
+            Vector3 previousPoint = center + axisX * radius;
+            for (int i = 1; i <= segments; i++)
+            {
+                float angle = (i / (float)segments) * Mathf.PI * 2f;
+                Vector3 nextPoint = center + (Mathf.Cos(angle) * axisX + Mathf.Sin(angle) * axisY) * radius;
+                Gizmos.DrawLine(previousPoint, nextPoint);
+                previousPoint = nextPoint;
+            }
+        }
+#endif
+
+        private void SampleObject(TrackedObject tracked, float currentTime)
+        {
+            Vector3 currentPosition = tracked.target.position;
+            List<Sample> samples = tracked.samples;
+
+            if (samples.Count == 0 || (currentPosition - samples[samples.Count - 1].position).sqrMagnitude >= minPointDistance * minPointDistance)
+            {
+                samples.Add(new Sample { position = currentPosition, time = currentTime });
+            }
+
+            // Remove stale samples.
+            for (int i = 0; i < samples.Count; i++)
+            {
+                if (currentTime - samples[i].time <= maxSampleAge)
+                {
+                    if (i > 0)
+                    {
+                        samples.RemoveRange(0, i);
+                    }
+                    return;
+                }
+            }
+
+            samples.Clear();
+            tracked.hasLastCircle = false;
+        }
+
+        private bool TryDetectCircle(TrackedObject tracked, float currentTime, out Vector3 center, out float radius)
+        {
+            center = Vector3.zero;
+            radius = 0f;
+
+            if (currentTime - tracked.lastCircleTime < detectionCooldown)
+            {
+                return false;
+            }
+
+            List<Sample> samples = tracked.samples;
+            if (samples.Count < minSampleCount)
+            {
+                return false;
+            }
+
+            Vector3 centroid = Vector3.zero;
+            foreach (Sample sample in samples)
+            {
+                centroid += sample.position;
+            }
+
+            centroid /= samples.Count;
+            Vector3 normal = EstimateNormal(samples, centroid);
+            if (normal.sqrMagnitude < 1e-6f)
+            {
+                return false;
+            }
+
+            normal.Normalize();
+            Vector3 axisX = Vector3.ProjectOnPlane(samples[samples.Count - 1].position - centroid, normal);
+            if (axisX.sqrMagnitude < 1e-6f)
+            {
+                axisX = Vector3.ProjectOnPlane(Vector3.right, normal);
+                if (axisX.sqrMagnitude < 1e-6f)
+                {
+                    axisX = Vector3.ProjectOnPlane(Vector3.up, normal);
+                }
+            }
+
+            axisX.Normalize();
+            Vector3 axisY = Vector3.Cross(normal, axisX).normalized;
+
+            float accumulatedRadius = 0f;
+            float totalSquaredError = 0f;
+            float travelledDistance = 0f;
+            Vector3 previous = samples[0].position;
+            List<float> angles = new List<float>(samples.Count);
+
+            for (int i = 0; i < samples.Count; i++)
+            {
+                Vector3 offset = samples[i].position - centroid;
+                Vector2 projected = new Vector2(Vector3.Dot(offset, axisX), Vector3.Dot(offset, axisY));
+
+                float pointRadius = projected.magnitude;
+                accumulatedRadius += pointRadius;
+                angles.Add(Mathf.Atan2(projected.y, projected.x));
+
+                if (i > 0)
+                {
+                    travelledDistance += Vector3.Distance(samples[i].position, previous);
+                }
+
+                previous = samples[i].position;
+            }
+
+            radius = accumulatedRadius / samples.Count;
+            if (radius < minCircleRadius)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < samples.Count; i++)
+            {
+                Vector3 offset = samples[i].position - centroid;
+                Vector2 projected = new Vector2(Vector3.Dot(offset, axisX), Vector3.Dot(offset, axisY));
+                float difference = projected.magnitude - radius;
+                totalSquaredError += difference * difference;
+            }
+
+            float standardDeviation = Mathf.Sqrt(totalSquaredError / samples.Count);
+            if (standardDeviation / radius > radiusVarianceTolerance)
+            {
+                return false;
+            }
+
+            float coverage = CalculateAngularCoverage(angles);
+            if (coverage < minCoverageAngle)
+            {
+                return false;
+            }
+
+            float circumference = 2f * Mathf.PI * radius;
+            float travelRatio = travelledDistance / Mathf.Max(circumference, 1e-5f);
+            if (travelRatio < minTravelledCircumferenceRatio)
+            {
+                return false;
+            }
+
+            center = centroid;
+            return true;
+        }
+
+        private static Vector3 EstimateNormal(List<Sample> samples, Vector3 centroid)
+        {
+            Vector3 normal = Vector3.zero;
+            for (int i = 0; i < samples.Count; i++)
+            {
+                Vector3 current = samples[i].position - centroid;
+                Vector3 next = samples[(i + 1) % samples.Count].position - centroid;
+                normal += Vector3.Cross(current, next);
+            }
+
+            return normal;
+        }
+
+        private static float CalculateAngularCoverage(List<float> angles)
+        {
+            angles.Sort();
+            float maxGap = 0f;
+
+            for (int i = 0; i < angles.Count - 1; i++)
+            {
+                float gap = angles[i + 1] - angles[i];
+                if (gap > maxGap)
+                {
+                    maxGap = gap;
+                }
+            }
+
+            if (angles.Count > 1)
+            {
+                float wrapGap = (angles[0] + Mathf.PI * 2f) - angles[angles.Count - 1];
+                if (wrapGap > maxGap)
+                {
+                    maxGap = wrapGap;
+                }
+            }
+
+            float coverage = Mathf.Rad2Deg * ((Mathf.PI * 2f) - maxGap);
+            return Mathf.Clamp(coverage, 0f, 360f);
+        }
+    }
+}

--- a/Assets/Scripts/Gestures/GestureDetector.cs.meta
+++ b/Assets/Scripts/Gestures/GestureDetector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 01302667ee034551badcdcaa86004891
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add a reusable `GestureDetector` component that samples object trails, recognises circular gestures, and exposes Unity events with debug tooling
- add a `CircularMover` helper script to drive an object around a pivot for testing
- update `SampleScene` with a demo pivot, tracked orb, and gesture system using the new scripts

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68cafb970e8083289f8eb266c65cac8d